### PR TITLE
Fix blurry mod descriptions

### DIFF
--- a/Source/ModManager/ModButton/ModButton_Installed.cs
+++ b/Source/ModManager/ModButton/ModButton_Installed.cs
@@ -571,7 +571,7 @@ namespace ModManager
             CrossPromotionManager.HandleCrossPromotions( ref canvas, Selected );
 
             Widgets.DrawBoxSolid( canvas, SlightlyDarkBackground);
-            var descriptionOutRect = canvas.ContractedBy(SmallMargin);
+            var descriptionOutRect = canvas.ContractedBy(SmallMargin).Rounded();
 
             // description
             var height2 = Text.CalcHeight(mod.Description, descriptionOutRect.width);


### PR DESCRIPTION
Some of mods' descriptions are blurry, because their drawing Rects aren't rounded to integers.